### PR TITLE
Add resource for headless rendering

### DIFF
--- a/example/conf/platform/horeka.yaml
+++ b/example/conf/platform/horeka.yaml
@@ -24,6 +24,8 @@ hydra:
       cpu:
       cuda:
         gpus: [0, 1, 2, 3]  # optional, will auto-detect if left blank
+      egl:
+        gpus: [0, 1, 2, 3]  # mandatory (for now)
       stagger:
         delay: 5
 

--- a/example/conf/platform/horeka.yaml
+++ b/example/conf/platform/horeka.yaml
@@ -24,8 +24,7 @@ hydra:
       cpu:
       cuda:
         gpus: [0, 1, 2, 3]  # optional, will auto-detect if left blank
-      pyglet:
-        gpus: [0, 1, 2, 3]  # mandatory (for now)
+      headless_render:
       stagger:
         delay: 5
 

--- a/example/conf/platform/horeka.yaml
+++ b/example/conf/platform/horeka.yaml
@@ -24,7 +24,8 @@ hydra:
       cpu:
       cuda:
         gpus: [0, 1, 2, 3]  # optional, will auto-detect if left blank
-      headless_render:
+      rendering:
+        gpus: [0, 1, 2, 3]  # optional, will auto-detect if left blank
       stagger:
         delay: 5
 

--- a/example/conf/platform/horeka.yaml
+++ b/example/conf/platform/horeka.yaml
@@ -24,7 +24,7 @@ hydra:
       cpu:
       cuda:
         gpus: [0, 1, 2, 3]  # optional, will auto-detect if left blank
-      egl:
+      pyglet:
         gpus: [0, 1, 2, 3]  # mandatory (for now)
       stagger:
         delay: 5

--- a/example/conf/platform/horeka.yaml
+++ b/example/conf/platform/horeka.yaml
@@ -23,9 +23,7 @@ hydra:
     resources_config:
       cpu:
       cuda:
-        gpus: [0, 1, 2, 3]  # optional, will auto-detect if left blank
       rendering:
-        gpus: [0, 1, 2, 3]  # optional, will auto-detect if left blank
       stagger:
         delay: 5
 

--- a/example/conf/platform/kluster.yaml
+++ b/example/conf/platform/kluster.yaml
@@ -21,7 +21,7 @@ hydra:
       cpu:
         cpus: [0, 1, 2, 3, 10, 11, 12, 13]  # since auto-detect fails, enumerate all CPUs
       cuda:
-      headless_render:
+      rendering:
       stagger:
         delay: 5
 

--- a/example/conf/platform/kluster.yaml
+++ b/example/conf/platform/kluster.yaml
@@ -21,6 +21,8 @@ hydra:
       cpu:
         cpus: [0, 1, 2, 3, 10, 11, 12, 13]  # since auto-detect fails, enumerate all CPUs
       cuda:
+      egl:
+        gpus: [0, 1, 2, 3]  # mandatory (for now)
       stagger:
         delay: 5
 

--- a/example/conf/platform/kluster.yaml
+++ b/example/conf/platform/kluster.yaml
@@ -21,8 +21,7 @@ hydra:
       cpu:
         cpus: [0, 1, 2, 3, 10, 11, 12, 13]  # since auto-detect fails, enumerate all CPUs
       cuda:
-      pyglet:
-        gpus: [0, 1, 2, 3]  # mandatory (for now)
+      headless_render:
       stagger:
         delay: 5
 

--- a/example/conf/platform/kluster.yaml
+++ b/example/conf/platform/kluster.yaml
@@ -21,7 +21,7 @@ hydra:
       cpu:
         cpus: [0, 1, 2, 3, 10, 11, 12, 13]  # since auto-detect fails, enumerate all CPUs
       cuda:
-      egl:
+      pyglet:
         gpus: [0, 1, 2, 3]  # mandatory (for now)
       stagger:
         delay: 5

--- a/example/conf/platform/slurm_debug.yaml
+++ b/example/conf/platform/slurm_debug.yaml
@@ -17,8 +17,7 @@ hydra:
     resources_config:
       cpu:
       cuda:
-      pyglet:
-        gpus: [0]  # mandatory (for now)
+      headless_render:
 
   # disable logging from job to stdout, as this pollutes slurm output
   job_logging:

--- a/example/conf/platform/slurm_debug.yaml
+++ b/example/conf/platform/slurm_debug.yaml
@@ -17,6 +17,8 @@ hydra:
     resources_config:
       cpu:
       cuda:
+      egl:
+        gpus: [0]  # mandatory (for now)
 
   # disable logging from job to stdout, as this pollutes slurm output
   job_logging:

--- a/example/conf/platform/slurm_debug.yaml
+++ b/example/conf/platform/slurm_debug.yaml
@@ -17,7 +17,7 @@ hydra:
     resources_config:
       cpu:
       cuda:
-      egl:
+      pyglet:
         gpus: [0]  # mandatory (for now)
 
   # disable logging from job to stdout, as this pollutes slurm output

--- a/example/conf/platform/slurm_debug.yaml
+++ b/example/conf/platform/slurm_debug.yaml
@@ -17,6 +17,7 @@ hydra:
     resources_config:
       cpu:
       cuda:
+      rendering:
 
   # disable logging from job to stdout, as this pollutes slurm output
   job_logging:

--- a/example/conf/platform/slurm_debug.yaml
+++ b/example/conf/platform/slurm_debug.yaml
@@ -17,7 +17,6 @@ hydra:
     resources_config:
       cpu:
       cuda:
-      headless_render:
 
   # disable logging from job to stdout, as this pollutes slurm output
   job_logging:

--- a/hydra_plugins/clusterduck_launcher/_resources.py
+++ b/hydra_plugins/clusterduck_launcher/_resources.py
@@ -194,13 +194,30 @@ class HeadlessRenderDevice(Resource):
     gpu: int
 
     def apply(self):
-        logger.debug(f"Setting EGL device ID to {self.gpu}")
+        logger.debug(
+            f"Setting device for EGL rendering (`EGL_DEVICE_ID`) to {self.gpu}"
+        )
         os.environ["EGL_DEVICE_ID"] = str(self.gpu)
-        logger.debug(f"Setting pyglet headless device to {self.gpu}")
+        # Reference:
+        # https://github.com/mmatl/pyrender/issues/92
+        # https://pyrender.readthedocs.io/en/latest/_modules/pyrender/offscreen.html
+        logger.debug(
+            f"Setting device for pyglet headless rendering (`PYGLET_HEADLESS_DEVICE`) to {self.gpu}"
+        )
         os.environ["PYGLET_HEADLESS_DEVICE"] = str(self.gpu)
+        # reference:
+        # https://pyglet.readthedocs.io/en/latest/programming_guide/options.html#pyglet.options
+        # https://github.com/pyglet/pyglet/issues/51
+        logger.debug(
+            f"Setting device for Mujoco headless rendering (`MUJOCO_EGL_DEVICE_ID`) to {self.gpu}"
+        )
+        os.environ["MUJOCO_EGL_DEVICE_ID"] = str(self.gpu)
+        # reference:
+        # https://github.com/google-deepmind/dm_control/issues/345
+        # https://pytorch.org/rl/reference/generated/knowledge_base/MUJOCO_INSTALLATION.html#common-issues-during-import-or-when-rendering-mujoco-environments
 
 
-class HeadlessRendering(GpuResources, kind="headless_render"):
+class HeadlessRendering(GpuResources, kind="rendering"):
     def __init__(
         self,
         kind: str,

--- a/hydra_plugins/clusterduck_launcher/_resources.py
+++ b/hydra_plugins/clusterduck_launcher/_resources.py
@@ -222,11 +222,11 @@ class HeadlessRendering(GpuResources, kind="rendering"):
         self,
         kind: str,
         n_workers: int,
-        gpus: Sequence[int],
+        gpus: Sequence[int] | None = None,
     ) -> None:
         if gpus is None:
             gpus = self.get_available_gpus()
-            logger.info(f"Auto-detected the following CUDA devices: {gpus}")
+            logger.info(f"Auto-detected the following GPU devices: {gpus}")
 
         n_gpus = len(gpus)
 


### PR DESCRIPTION
Rename most resource types.
Resource type registration is now optional for subclasses.
Cuda resource now inherits from new GpuResources type.
Add HeadlessRendering rseource for setting environment variables related to EGL rendering.
Add rendering resource to example configs.
Update README.