### PR TITLE
Small changes to example configs

### DIFF
--- a/example/conf/platform/horeka.yaml
+++ b/example/conf/platform/horeka.yaml
@@ -8,7 +8,7 @@ hydra:
   mode: MULTIRUN  # needed for launcher to be used
   launcher:
     # launcher/cluster specific options
-    timeout_min: 5
+    timeout_min: ???
     partition: dev_accelerated
     gres: gpu:4
     setup:

--- a/example/conf/platform/horeka.yaml
+++ b/example/conf/platform/horeka.yaml
@@ -19,7 +19,8 @@ hydra:
       - export WANDB_CONSOLE=off
 
     # clusterduck specific options
-    parallel_runs_per_node: 2
+    parallel_runs_per_node: 4
+    total_runs_per_node: null  # optional. None puts all runs into one slurm job
     resources_config:
       cpu:
       cuda:

--- a/example/conf/platform/kluster.yaml
+++ b/example/conf/platform/kluster.yaml
@@ -8,7 +8,7 @@ hydra:
   mode: MULTIRUN  # needed for launcher to be used
   launcher:
     # launcher/cluster specific options
-    timeout_min: 5
+    timeout_min: ???
     gres: gpu:4  # we want all GPUs in a node
     mem_per_cpu: 15000  # in MB (* 8 cores in use = 120GB)
     # exclude: node[4-5]  # e.g. do not allocate on these nodes because the RTX2080 doesn't have enough VRAM

--- a/example/conf/platform/kluster.yaml
+++ b/example/conf/platform/kluster.yaml
@@ -17,6 +17,7 @@ hydra:
 
     # clusterduck specific options
     parallel_runs_per_node: 4
+    total_runs_per_node: null  # optional. None puts all runs into one slurm job
     resources_config:
       cpu:
         cpus: [0, 1, 2, 3, 10, 11, 12, 13]  # since auto-detect fails, enumerate all CPUs

--- a/example/conf/platform/slurm_debug.yaml
+++ b/example/conf/platform/slurm_debug.yaml
@@ -8,7 +8,7 @@ hydra:
   mode: MULTIRUN  # needed for launcher to be used
   launcher:
     # launcher/cluster specific options
-    timeout_min: 5
+    timeout_min: ???
     gpus_per_node: 1  # by default, submitit local executor uses 0 gpus
 
     # clusterduck specific options

--- a/hydra_plugins/clusterduck_launcher/config.py
+++ b/hydra_plugins/clusterduck_launcher/config.py
@@ -8,7 +8,7 @@ from hydra.core.config_store import ConfigStore
 class BaseQueueConf:
     """Configuration shared by all executors"""
 
-    submitit_folder: str = "${hydra.sweep.dir}/.submitit/%j"
+    submitit_folder: str = "${hydra.sweep.dir}/submitit/%j"
 
     # maximum time for the job in minutes
     timeout_min: int = 60


### PR DESCRIPTION
Several users were not aware of the slurm error log file, because the submitit folder was hidden. This is now fixed.
One user also forgot to change the timeout for their job. Should we set the timeouts to MISSING in the example configs?