### PR TITLE
Updated the example config to include the resources config tab.

### DIFF
--- a/example/conf/platform/horeka.yaml
+++ b/example/conf/platform/horeka.yaml
@@ -24,6 +24,7 @@ hydra:
     resources_config:
       cpu:
       cuda:
+        gpus: [0, 1, 2, 3]  # Auto-detect has failed on Horeka accelerated nodes. Enumerate all GPUs manually.
       rendering:
       stagger:
         delay: 5


### PR DESCRIPTION
There is a problem that Horeka does not find the GPUs automatically, hence all the 4 jobs get scheduled on one GPU. The manual resources_config solves this problem.